### PR TITLE
Security policy and relay enrollment hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Remota is young and moving fast, and **your feedback shapes it** — please don'
 - 💡 **Want a feature or another protocol?** Open an issue and tell us what you need.
 - 🔧 **Code?** Pull requests are welcome. Remota is **clean-room** — please don't paste code from
   other remote-connection managers.
+- 🔒 **Found a security issue?** Please report it privately — see [`SECURITY.md`](./SECURITY.md).
 
 Browse existing issues first: **[github.com/privum-cloud/remota/issues](https://github.com/privum-cloud/remota/issues)**.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,72 @@
+# Security Policy
+
+Remota is a remote-access tool: it holds credentials and brokers connections to machines that
+matter. Security reports are welcome and taken seriously.
+
+## Reporting a vulnerability
+
+**Please report privately, through GitHub's private vulnerability reporting:**
+[github.com/privum-cloud/remota/security/advisories/new](https://github.com/privum-cloud/remota/security/advisories/new)
+(the **Security** tab → *Report a vulnerability*). That channel is private to the maintainers and
+lets us credit you and publish an advisory once a fix ships.
+
+Please do **not** open a public issue for an unfixed vulnerability.
+
+A useful report includes:
+
+- the component (desktop app, `server/relay`, `server/agent`) and the affected file/function;
+- the commit or release you looked at;
+- what an attacker can actually do, and what they need first (network position, a valid token, a
+  local account, an unlocked vault…);
+- a proof of concept if you have one — and if you don't, say so plainly. A well-scoped source
+  review is welcome; please don't present an unverified inference as a demonstrated exploit.
+
+We aim to acknowledge a report within a few days. Remota is maintained by a small team, so please
+allow reasonable time for a fix before public disclosure. We'll credit you by name in the release
+notes and the advisory unless you'd rather stay anonymous.
+
+Remota is open source (AGPL-3.0-only) — if you'd like to fix what you found, a pull request is very
+welcome. For an unfixed vulnerability, report it privately first and we'll coordinate the PR.
+
+## Supported versions
+
+Fixes land on `main` and go out in the next release. Only the latest release is supported; there
+are no backports to older 0.1.x versions.
+
+## Scope
+
+In scope: the desktop app (encrypted vault, local WebSocket gateway, SSH/RDP/VNC/Telnet
+transports), the self-hosted relay (`server/relay`), the agent (`server/agent`), and the
+deployment material under `server/deploy/`.
+
+## Known limitations — please don't report these as new
+
+These are documented, deliberate properties of the current release, not undiscovered bugs. They
+are on the roadmap; a report that only restates one of them will be closed as known. What *is*
+useful is a concrete attack that these limitations enable in a **documented, recommended**
+configuration.
+
+- **`POST /session` and `GET /agents` on the relay have no authentication of their own.** They are
+  gated at the reverse proxy by source IP (the shipped `Caddyfile` fails closed). Per-user
+  authentication is planned.
+- **No per-device authorization.** An operator who can reach `POST /session` can broker a tunnel to
+  any registered agent's target port; knowing the device ID is enough. A per-device password /
+  accept prompt is planned.
+- **SSH host keys are accepted without verification** (no `known_hosts`) — in the app and on the
+  jump-host leg. This is a known gap, not a design goal.
+- **The RDP gateway does not validate the Windows host's certificate.** It forwards the server
+  certificate chain to the `ironrdp-web` client, which performs CredSSP channel binding.
+- **`export_connections` writes plaintext JSON**, including passwords. It is an explicit, operator
+  initiated export.
+- **Vault credentials are held as plain `String` in memory** and are not zeroized on lock.
+- **A brokered relay session whose two legs never pair is kept until the relay restarts.** Its
+  single-use token stays valid, and the session map grows. Reaching it still requires the
+  session's UUIDv4 id, which is only sent to the app and the agent.
+- Attacks that require an attacker who already has local code execution as the user, or a vault
+  that is already unlocked, are out of scope.
+
+## Deployment hardening
+
+If you self-host the relay, read `server/deploy/README.md` before exposing it. In particular: set a
+strong `REMOTA_ENROLL_TOKEN` (the relay refuses to start without one) and edit the operator IP
+allowlist in `Caddyfile` — as shipped, the brokering endpoints answer `403` to everyone.

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -723,6 +723,8 @@ dependencies = [
  "remota-proto",
  "serde",
  "serde_json",
+ "sha2",
+ "subtle",
  "tokio",
  "tokio-tungstenite 0.24.0",
  "uuid",
@@ -866,6 +868,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/server/deploy/Caddyfile
+++ b/server/deploy/Caddyfile
@@ -2,24 +2,41 @@
 # Caddy obtains/renews a Let's Encrypt cert automatically and proxies the
 # control (/agent/control) and data (/data/{id}) WebSocket upgrades transparently.
 #
-# Place at /etc/caddy/Caddyfile, then: sudo systemctl reload caddy
+# Place at /etc/caddy/Caddyfile, then:
+#   sudo caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
+#   sudo systemctl reload caddy
 # DNS: point relay.privum.cloud (A/AAAA) at this host; open TCP 80 + 443.
+#
+# ⚠️ EDIT TWO THINGS BEFORE GOING LIVE:
+#   1. the site address below, if it is not relay.privum.cloud
+#   2. the @brokering_denied IP range — as shipped it allows nobody, so /session
+#      and /agents answer 403 to everyone (fail closed, by design)
 
 relay.privum.cloud {
 	encode zstd gzip
 
-	# The agent connects to wss://relay.privum.cloud/agent/control
-	# The app connects to  wss://relay.privum.cloud/data/{id}?token=...&role=client
-	reverse_proxy 127.0.0.1:8787
+	# --- Brokering plane: operators only ------------------------------------
+	# POST /session and GET /agents have no authentication of their own yet
+	# (per-user auth is Phase 3): anyone who can reach them can list registered
+	# agents and broker a tunnel to an agent's target_port. So they are gated
+	# here, by source IP.
+	#
+	# REPLACE the placeholder range below with your VPN / office ranges, e.g.
+	#   not remote_ip 10.10.0.0/24 203.0.113.7
+	# The documentation range 192.0.2.0/24 is a deliberate placeholder: leaving
+	# it as-is denies everyone rather than silently exposing the endpoints.
+	@brokering_denied {
+		path /session /session/* /agents /agents/*
+		not remote_ip 192.0.2.0/24
+	}
 
-	# --- MVP security note -------------------------------------------------
-	# POST /session and GET /agents are currently UNAUTHENTICATED: anyone who can
-	# reach this host can broker a tunnel to a registered agent's target_port.
-	# Until per-user auth lands (Phase 3), restrict who can reach the relay, e.g.
-	# only the team VPN / office IPs:
+	# --- Agent + data planes: open ------------------------------------------
+	# /agent/control must stay reachable from anywhere (agents dial out from
+	# behind NAT), and /data/{id} is gated by the single-use per-session token.
 	#
-	#   @notvpn not remote_ip 10.10.0.0/24 <your-office-cidr>
-	#   respond @notvpn 403
-	#
-	# (Agents still need outbound reach; this only gates inbound brokering.)
+	# `route` keeps these in the written order: deny first, then proxy.
+	route {
+		respond @brokering_denied 403
+		reverse_proxy 127.0.0.1:8787
+	}
 }

--- a/server/deploy/README.md
+++ b/server/deploy/README.md
@@ -26,9 +26,15 @@ curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
   | sudo tee /etc/apt/sources.list.d/caddy-stable.list
 sudo apt update && sudo apt install -y caddy
 
-sudo cp Caddyfile /etc/caddy/Caddyfile     # edit the domain if not relay.privum.cloud
+sudo cp Caddyfile /etc/caddy/Caddyfile
+sudoedit /etc/caddy/Caddyfile              # set the domain, and the operator IP allowlist
+sudo caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
 sudo systemctl reload caddy                 # Caddy fetches the Let's Encrypt cert on first hit
 ```
+
+The shipped `Caddyfile` **fails closed**: `POST /session` and `GET /agents` answer `403` until you
+replace the placeholder range (`192.0.2.0/24`) with your VPN / office CIDRs. `/agent/control` and
+`/data/{id}` stay open — agents dial out from behind NAT and must always reach the relay.
 
 ## 3. Install the relay
 
@@ -79,11 +85,17 @@ bridges raw bytes — so a TCP service like `sshd` on the target is reachable th
 
 ## Security (MVP limitations — read before exposing)
 
-- **Enrollment** is a single shared token (`REMOTA_ENROLL_TOKEN`). Rotate it by editing
-  `/etc/remota/relay.env` and `systemctl restart remota-relay`.
-- **`POST /session` and `GET /agents` are unauthenticated.** Anyone who can reach the relay can
-  broker a tunnel to a registered agent's `target_port`. Until per-user auth lands (Phase 3),
-  gate inbound access — e.g. only the team VPN / office IPs (see the commented block in
-  `Caddyfile`). Agents still reach the relay outbound regardless.
-- **Session tokens are single-use** and consumed when the two legs pair.
+- **Enrollment** is a single shared token (`REMOTA_ENROLL_TOKEN`), **required**: the relay refuses
+  to start if it is unset, under 16 characters, or the old `dev-enroll` placeholder. Rotate it by
+  editing `/etc/remota/relay.env` and `systemctl restart remota-relay`.
+- **`POST /session` and `GET /agents` are unauthenticated.** Anyone who can reach them can list
+  registered agents and broker a tunnel to an agent's `target_port`. Until per-user auth lands
+  (Phase 3) they are gated by source IP in `Caddyfile`, which ships denying everyone — set your
+  own allowlist. Agents still reach the relay outbound regardless.
+- **Session tokens are single-use** and consumed when the two legs pair. Reaching the token check
+  at all requires the session's UUIDv4 id, which is only ever sent to the app and the agent.
+  A brokered session whose legs never pair is currently kept until the relay restarts.
+- **Enrollment and session tokens are compared in constant time**, so a failed attempt leaks
+  neither the secret's contents nor its length. There is **no rate limiting** on the WebSocket
+  handshakes yet — put one in front of the relay if it is exposed to the open internet.
 - TLS is handled entirely by Caddy; the relay speaks plain HTTP on loopback.

--- a/server/deploy/install.sh
+++ b/server/deploy/install.sh
@@ -39,6 +39,16 @@ if ! sudo test -f /etc/remota/relay.env; then
 	sudo chown remota:remota /etc/remota/relay.env
 	sudo chmod 640 /etc/remota/relay.env
 	echo ">> generated /etc/remota/relay.env with a new enrollment token"
+else
+	# Existing file: the relay refuses to start on a placeholder/short token, so catch it
+	# here instead of leaving a dead service behind a "success" message.
+	EXISTING="$(sudo sed -n 's/^REMOTA_ENROLL_TOKEN=//p' /etc/remota/relay.env | tail -1)"
+	if [[ -z "$EXISTING" || "$EXISTING" == "dev-enroll" || "$EXISTING" == CHANGE_ME* || ${#EXISTING} -lt 16 ]]; then
+		echo "!! /etc/remota/relay.env has no usable REMOTA_ENROLL_TOKEN." >&2
+		echo "   The relay will refuse to start. Set a long random secret:" >&2
+		echo "   head -c 32 /dev/urandom | base64 | tr -d '/+=' | head -c 40" >&2
+		exit 1
+	fi
 fi
 
 # 5) systemd unit.

--- a/server/deploy/relay.env.example
+++ b/server/deploy/relay.env.example
@@ -3,7 +3,9 @@
 # The relay listens on loopback only; Caddy terminates TLS on 443 and proxies here.
 REMOTA_RELAY_LISTEN=127.0.0.1:8787
 
-# Shared enrollment secret an agent must present on Register. Use a long random value:
+# Shared enrollment secret an agent must present on Register. REQUIRED — the relay refuses to
+# start if it is unset, shorter than 16 characters, or left at the old "dev-enroll" placeholder.
+# Generate a long random value:
 #   head -c 32 /dev/urandom | base64 | tr -d '/+=' | head -c 40
 # install.sh generates one for you if this file does not exist yet.
 REMOTA_ENROLL_TOKEN=CHANGE_ME_to_a_long_random_secret

--- a/server/relay/Cargo.toml
+++ b/server/relay/Cargo.toml
@@ -13,6 +13,9 @@ futures-util = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
+# Constant-time secret comparison (enrollment + session tokens).
+sha2 = "0.10"
+subtle = "2"
 
 [dev-dependencies]
 remota-agent = { path = "../agent" }

--- a/server/relay/src/lib.rs
+++ b/server/relay/src/lib.rs
@@ -23,6 +23,8 @@ use axum::{
 };
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -66,6 +68,53 @@ fn relay_text(msg: &RelayMsg) -> Message {
     Message::Text(serde_json::to_string(msg).expect("RelayMsg serializes").into())
 }
 
+// ---- secrets --------------------------------------------------------------
+
+/// The placeholder enrollment secret this relay used to fall back to. It is public knowledge
+/// (it is in the git history and in the docs), so a deployment must never run with it.
+pub const INSECURE_ENROLL_TOKEN: &str = "dev-enroll";
+
+/// Shortest enrollment secret we accept. `install.sh` generates 40 random characters.
+pub const MIN_ENROLL_TOKEN_LEN: usize = 16;
+
+/// Compare two secrets without branching on their contents.
+///
+/// Both operands are hashed to a fixed-size digest first: `ct_eq` over the raw bytes is still
+/// length-dependent, so hashing keeps *both* the contents and the length of the secret out of
+/// the timing. Cheap enough — this runs once per connection attempt, not per byte.
+fn secret_eq(a: &str, b: &str) -> bool {
+    let a = Sha256::digest(a.as_bytes());
+    let b = Sha256::digest(b.as_bytes());
+    a.ct_eq(&b).into()
+}
+
+/// Validate the operator-supplied enrollment secret at startup.
+///
+/// The relay refuses to run without a real one: an unset or placeholder token means any host on
+/// the internet can register an agent, and `/agent/control` is deliberately reachable from
+/// anywhere (agents dial out from behind NAT). Fail loudly at boot rather than quietly serve.
+pub fn validate_enroll_token(value: Option<&str>) -> Result<String, String> {
+    const HOWTO: &str =
+        "Generate one with:  head -c 32 /dev/urandom | base64 | tr -d '/+=' | head -c 40\n\
+         and set REMOTA_ENROLL_TOKEN (see server/deploy/relay.env.example).";
+    let token = value.unwrap_or("").trim();
+    if token.is_empty() {
+        return Err(format!("REMOTA_ENROLL_TOKEN is not set.\n{HOWTO}"));
+    }
+    if token == INSECURE_ENROLL_TOKEN {
+        return Err(format!(
+            "REMOTA_ENROLL_TOKEN is still the placeholder {INSECURE_ENROLL_TOKEN:?}, which is \
+             publicly known.\n{HOWTO}"
+        ));
+    }
+    if token.chars().count() < MIN_ENROLL_TOKEN_LEN {
+        return Err(format!(
+            "REMOTA_ENROLL_TOKEN is too short (minimum {MIN_ENROLL_TOKEN_LEN} characters).\n{HOWTO}"
+        ));
+    }
+    Ok(token.to_string())
+}
+
 // ---- control channel ------------------------------------------------------
 
 async fn agent_control(ws: WebSocketUpgrade, State(st): State<AppState>) -> Response {
@@ -89,7 +138,9 @@ async fn handle_agent_control(socket: WebSocket, st: AppState) {
             return;
         }
     };
-    if token != *st.enroll_token {
+    // Constant-time: `/agent/control` is open to the internet, so this comparison is the one
+    // attacker-reachable check on a long-lived shared secret.
+    if !secret_eq(&token, &st.enroll_token) {
         let _ = sink.send(relay_text(&RelayMsg::Error { msg: "bad enrollment token".into() })).await;
         return;
     }
@@ -190,7 +241,14 @@ async fn data_channel(
     State(st): State<AppState>,
 ) -> Response {
     // Validate token against the session, but do NOT consume it yet — both legs present it.
-    let valid = matches!(st.sessions.lock().await.get(&id), Some(s) if s.token == q.token);
+    // Reaching the comparison at all requires knowing `id`, a UUIDv4 that only the app and the
+    // agent are told, so this is not an oracle on the token; compare in constant time anyway.
+    // NOTE: a brokered session whose legs never pair is never removed from the map — see the
+    // known-limitations list in SECURITY.md.
+    let valid = match st.sessions.lock().await.get(&id) {
+        Some(s) => secret_eq(&s.token, &q.token),
+        None => false,
+    };
     if !valid {
         return (StatusCode::FORBIDDEN, "bad session or token").into_response();
     }
@@ -202,4 +260,50 @@ async fn data_channel(
     ws.on_upgrade(move |socket| async move {
         rendezvous(&st.rendezvous, &st.sessions, id, role, socket).await;
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn secret_eq_matches_only_identical_secrets() {
+        assert!(secret_eq("s3cret-token", "s3cret-token"));
+        assert!(!secret_eq("s3cret-token", "s3cret-tokeM"));
+        // Length differences must not be treated as a match either.
+        assert!(!secret_eq("s3cret-token", "s3cret-token-longer"));
+        assert!(!secret_eq("", "s3cret-token"));
+        assert!(secret_eq("", ""));
+    }
+
+    #[test]
+    fn enroll_token_must_be_set() {
+        assert!(validate_enroll_token(None).is_err());
+        assert!(validate_enroll_token(Some("")).is_err());
+        assert!(validate_enroll_token(Some("   ")).is_err());
+    }
+
+    #[test]
+    fn enroll_token_rejects_the_public_placeholder() {
+        let err = validate_enroll_token(Some(INSECURE_ENROLL_TOKEN)).unwrap_err();
+        assert!(err.contains("publicly known"), "{err}");
+    }
+
+    #[test]
+    fn enroll_token_rejects_short_secrets() {
+        assert!(validate_enroll_token(Some("short")).is_err());
+        let ok = "x".repeat(MIN_ENROLL_TOKEN_LEN);
+        assert_eq!(validate_enroll_token(Some(&ok)).unwrap(), ok);
+    }
+
+    #[test]
+    fn enroll_token_is_trimmed() {
+        // Env files and shell exports pick up stray whitespace; a token that differs only by
+        // trailing newline must not silently become a *different* secret.
+        let token = "  a-perfectly-fine-enrollment-secret  ";
+        assert_eq!(
+            validate_enroll_token(Some(token)).unwrap(),
+            "a-perfectly-fine-enrollment-secret"
+        );
+    }
 }

--- a/server/relay/src/main.rs
+++ b/server/relay/src/main.rs
@@ -2,16 +2,25 @@
 //!
 //! Env:
 //!   REMOTA_RELAY_LISTEN  (default 127.0.0.1:8787)
-//!   REMOTA_ENROLL_TOKEN  (default "dev-enroll" — set a real secret in production)
+//!   REMOTA_ENROLL_TOKEN  (REQUIRED — the relay refuses to start without a real secret)
 //!
 //! TLS is terminated by a reverse proxy in front of the relay (see lib.rs / M-agent-0 plan).
 
-use remota_relay::build_app;
+use remota_relay::{build_app, validate_enroll_token};
 
 #[tokio::main]
 async fn main() {
     let listen = std::env::var("REMOTA_RELAY_LISTEN").unwrap_or_else(|_| "127.0.0.1:8787".into());
-    let enroll = std::env::var("REMOTA_ENROLL_TOKEN").unwrap_or_else(|_| "dev-enroll".into());
+
+    // No usable default: `/agent/control` is reachable from anywhere by design, so a placeholder
+    // secret would let any host on the internet register an agent. Refuse to serve instead.
+    let enroll = match validate_enroll_token(std::env::var("REMOTA_ENROLL_TOKEN").ok().as_deref()) {
+        Ok(token) => token,
+        Err(why) => {
+            eprintln!("remota-relay: refusing to start.\n{why}");
+            std::process::exit(1);
+        }
+    };
 
     let app = build_app(enroll);
     let listener = tokio::net::TcpListener::bind(&listen)


### PR DESCRIPTION
Adds a security policy and hardens the self-hosted relay.

## Security policy

`SECURITY.md` points reporters at GitHub's private vulnerability reporting, says what a useful report contains, and lists the known MVP limitations so they are not re-reported as new findings.

## Relay hardening

- **The enrollment secret has no default any more.** `/agent/control` is reachable from the internet by design, so falling back to the public `dev-enroll` placeholder let anyone register an agent. The relay now refuses to start when `REMOTA_ENROLL_TOKEN` is unset, shorter than 16 characters, or still the placeholder.
- **The shipped `Caddyfile` fails closed.** `POST /session` and `GET /agents` have no authentication of their own; the IP allowlist that gates them used to be a commented-out suggestion, so a deployment that copied the file as-is exposed session brokering. The allowlist is now active with a documentation-range placeholder that denies everyone until an operator sets their own CIDRs.
- **Tokens are compared in constant time.** Both operands are hashed to a SHA-256 digest before `subtle::ConstantTimeEq`, since a raw byte comparison still short-circuits on length. The session-token comparison was never an oracle — it is unreachable without the session's UUIDv4 id — but both are now uniform.
- `install.sh` fails loudly when an existing `relay.env` carries a placeholder token, instead of leaving a dead service behind a success message.

The timing comparison (CWE-208) was reported by Abdurazzoqov Javohir via source review.

## Verification

- `cargo test` green in `server/` (6 new unit tests plus the existing end-to-end echo test).
- `cargo clippy --all-targets` clean.
- Startup refusal checked against the release binary for an unset token, the `dev-enroll` placeholder and a short token; it still serves normally with a good one.
- The `Caddyfile` was **not** validated by a Caddy binary. `caddy validate` is now a documented step before `systemctl reload`.

## Not included

- No rate limiting on the WebSocket handshakes.
- A brokered session whose two legs never pair is still kept until the relay restarts. Documented in `SECURITY.md`.