### PR TITLE
In-app auto-update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: ci
+
+on:
+  push:
+    # Feature branches too, so a broken workflow surfaces on the branch that
+    # broke it rather than at merge time.
+    branches: [main, "feat/**", "fix/**", "deps/**", "build/**", "release/**"]
+  pull_request:
+
+jobs:
+  # The desktop app. src-tauri and server are separate cargo workspaces and
+  # neither builds the other, so both need their own job.
+  app:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+
+      # Tauri links against the system webkit; without these the crate does not
+      # build, even though nothing under test touches a window.
+      - name: Install the libraries Tauri links against
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev \
+            libayatana-appindicator3-dev patchelf
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Lint
+        run: cargo clippy --all-targets
+        working-directory: src-tauri
+
+      # The four #[ignore] tests need a live sshd, a live relay or a reachable
+      # Windows host, so they stay out of CI and are run by hand.
+      - name: Test
+        run: cargo test
+        working-directory: src-tauri
+
+  # The self-hosted relay and the agent.
+  server:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: server
+      - name: Lint
+        run: cargo clippy --all-targets
+        working-directory: server
+      - name: Test
+        run: cargo test
+        working-directory: server
+
+  # npm run build is tsc followed by vite build, so this is the typecheck too.
+  web:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,97 @@
+name: release
+
+# Fires on a version tag. Everything below is what used to be a person at a
+# terminal, which meant a release could only happen when that person was free.
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+env:
+  # gh is preinstalled on every runner and reads this.
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  # A draft first, so the build job has somewhere to upload to and a
+  # half-finished release is never visible.
+  draft:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Open a draft release
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" \
+            --title "Remota ${GITHUB_REF_NAME#v}" \
+            --draft --generate-notes
+
+  linux:
+    needs: draft
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install the libraries Tauri links against
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev \
+            libayatana-appindicator3-dev patchelf
+
+      # rustup ships with the runner. This workflow produces the binaries people
+      # install; the fewer hands on that path the better.
+      - name: Show the toolchain
+        run: rustc --version && cargo --version
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+      - run: npm run tauri build -- --bundles deb,rpm,appimage
+        env:
+          # Without these the bundler still builds, but produces no .sig files
+          # and the manifest step below refuses to publish an empty manifest.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+
+      - name: Attach the packages and their signatures
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" --clobber \
+            src-tauri/target/release/bundle/deb/*.deb \
+            src-tauri/target/release/bundle/deb/*.deb.sig \
+            src-tauri/target/release/bundle/rpm/*.rpm \
+            src-tauri/target/release/bundle/rpm/*.rpm.sig \
+            src-tauri/target/release/bundle/appimage/*.AppImage \
+            src-tauri/target/release/bundle/appimage/*.AppImage.sig
+
+  publish:
+    needs: linux
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+
+      # Installed copies find this file at releases/latest/download/latest.json,
+      # so it has to be attached before the draft is lifted: the moment this
+      # release becomes "latest" is the moment that URL starts resolving here.
+      # Publishing first would leave a window in which installed copies fetch
+      # the previous release's manifest.
+      - name: Build and attach the update manifest
+        run: |
+          gh release download "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" --pattern '*.sig' --dir sigs
+          python3 scripts/build-update-manifest.py \
+            --tag "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" \
+            --sigs sigs --out latest.json
+          gh release upload "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" --clobber latest.json
+
+      - name: Publish
+        run: |
+          gh release edit "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" --draft=false --latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remota",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remota",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@novnc/novnc": "^1.7.0",
@@ -14,6 +14,8 @@
         "@tauri-apps/plugin-clipboard-manager": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-process": "^2",
+        "@tauri-apps/plugin-updater": "^2",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "ironrdp-wasm": "^1.1.0",
@@ -1415,6 +1417,24 @@
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.4.tgz",
       "integrity": "sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.11.0.tgz",
+      "integrity": "sha512-AE36XkOoSna24G40jZMY15nzAnkXEPL/73tGoseGrtGOHuI/cZwWzHpZFLjKXDPgzYZ435z1gHu28LgrsBwIxQ==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@tauri-apps/plugin-clipboard-manager": "^2",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-process": "^2",
+    "@tauri-apps/plugin-updater": "^2",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "ironrdp-wasm": "^1.1.0",

--- a/scripts/build-update-manifest.py
+++ b/scripts/build-update-manifest.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Assemble the update manifest the updater plugin reads.
+
+The plugin looks for `{os}-{arch}-{installer}` before falling back to `{os}-{arch}`, so one
+manifest can carry a different artefact for each package format. That is what lets someone who
+installed the .deb be handed a .deb rather than an AppImage they cannot install.
+
+Signatures are read from the .sig files the bundler produced, and the download URL is derived from
+the asset each one signs. Nothing here invents a filename: if a package was not built and signed,
+it simply does not appear, and the updater tells that platform there is nothing for it rather than
+handing it the wrong file.
+"""
+
+import argparse
+import datetime
+import json
+import pathlib
+import sys
+
+# Which manifest key each signed artefact belongs under. Remota ships Linux x86_64 only.
+TARGETS = [
+    (".AppImage.sig", "linux-x86_64-appimage"),
+    (".deb.sig", "linux-x86_64-deb"),
+    (".rpm.sig", "linux-x86_64-rpm"),
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--sigs", required=True, type=pathlib.Path)
+    parser.add_argument("--out", required=True, type=pathlib.Path)
+    args = parser.parse_args()
+
+    base = f"https://github.com/{args.repo}/releases/download/{args.tag}"
+    platforms = {}
+
+    for sig in sorted(args.sigs.iterdir()):
+        for suffix, key in TARGETS:
+            if sig.name.endswith(suffix):
+                platforms[key] = {
+                    "signature": sig.read_text().strip(),
+                    # The signature file sits beside what it signs.
+                    "url": f"{base}/{sig.name[: -len('.sig')]}",
+                }
+                break
+        else:
+            print(f"warning: no target for {sig.name}", file=sys.stderr)
+
+    if not platforms:
+        print("error: no signatures found; refusing to publish an empty manifest", file=sys.stderr)
+        return 1
+
+    manifest = {
+        "version": args.tag.lstrip("v"),
+        "pub_date": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "platforms": platforms,
+    }
+    args.out.write_text(json.dumps(manifest, indent=2) + "\n")
+    print(json.dumps({k: v["url"] for k, v in platforms.items()}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -120,6 +120,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,6 +826,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -838,7 +857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -851,7 +870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -1154,6 +1173,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1590,6 +1620,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2284,6 +2324,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,9 +2356,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2606,6 +2663,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2825,6 +2912,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -3151,6 +3244,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3232,6 +3337,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3255,6 +3366,20 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4000,6 +4125,8 @@ dependencies = [
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
+ "tauri-plugin-updater",
  "tokio",
  "tokio-rustls",
  "tokio-tungstenite 0.24.0",
@@ -4022,15 +4149,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4255,6 +4387,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4262,6 +4406,33 @@ checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4303,6 +4474,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4386,6 +4566,29 @@ dependencies = [
  "hybrid-array",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4706,6 +4909,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4951,6 +5170,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4971,7 +5211,7 @@ checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -4981,7 +5221,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -5015,6 +5255,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5037,7 +5288,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -5229,6 +5480,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b28d8cabdeb0564f03ae261963de4bc3d98321cd3d213e76a81b7d344e5df606"
+dependencies = [
+ "base64 0.22.1",
+ "dirs 6.0.0",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5238,7 +5532,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -5261,7 +5555,7 @@ checksum = "fe41e015bf8fc4d6477ff4926a0ef769dc64ff34c7b0038b6f7cacae892acb5c"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -6234,6 +6528,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6482,6 +6785,17 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core 0.62.2",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -6937,7 +7251,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -7000,6 +7314,16 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"
@@ -7163,6 +7487,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,8 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-clipboard-manager = "2"
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 roxmltree = "0.20"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,12 +2,16 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
-  "windows": ["main"],
+  "windows": [
+    "main"
+  ],
   "permissions": [
     "core:default",
     "opener:default",
     "dialog:default",
     "clipboard-manager:allow-read-text",
-    "clipboard-manager:allow-write-text"
+    "clipboard-manager:allow-write-text",
+    "updater:default",
+    "process:allow-restart"
   ]
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5,6 +5,8 @@ use tauri::State;
 
 use crate::gateway::{SessionKind, SessionRegistry, SessionSpec};
 use crate::model::{Document, Gateway, Node, Relay};
+use crate::settings::Settings;
+use crate::update::{delivery, Delivery, RELEASES_URL};
 use crate::vault::{VaultError, VaultManager};
 
 pub struct AppState {
@@ -151,6 +153,37 @@ pub fn import_remota_json(state: State<AppState>, path: String) -> Result<Import
         connections,
         message: format!("{connections} connections imported from Remota JSON."),
     })
+}
+
+/// What Remota may do about a newer version, and whether it is allowed to look.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdatePolicy {
+    pub delivery: Delivery,
+    pub enabled: bool,
+    pub releases_url: String,
+    pub current_version: String,
+}
+
+/// Read before the vault is unlocked, because that is when it is needed: whoever has not opened
+/// Remota in a month is exactly the person who has not heard about the release that fixed
+/// something, and they should not have to unlock a vault to find out.
+#[tauri::command]
+pub fn update_policy() -> UpdatePolicy {
+    UpdatePolicy {
+        delivery: delivery(),
+        enabled: Settings::load().check_for_updates,
+        releases_url: RELEASES_URL.to_owned(),
+        current_version: env!("CARGO_PKG_VERSION").to_owned(),
+    }
+}
+
+#[tauri::command]
+pub fn set_update_check(enabled: bool) -> Result<bool, String> {
+    let mut s = Settings::load();
+    s.check_for_updates = enabled;
+    s.save()?;
+    Ok(enabled)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod gateway;
 mod importer;
 mod model;
 mod settings;
+mod update;
 mod vault;
 
 use std::sync::Arc;
@@ -14,10 +15,20 @@ use gateway::SessionRegistry;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    #[allow(unused_mut)]
+    let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_process::init());
+
+    // Desktop only: a phone has no package to replace.
+    #[cfg(desktop)]
+    {
+        builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
+    }
+
+    builder
         .setup(|app| {
             // CryptoProvider (ring) para o rustls 0.23 — usado pelas conexões "relayed" (wss).
             gateway::relay::ensure_crypto_provider();
@@ -50,7 +61,9 @@ pub fn run() {
             commands::empty_trash,
             commands::import_mremoteng,
             commands::export_connections,
-            commands::import_remota_json
+            commands::import_remota_json,
+            commands::update_policy,
+            commands::set_update_check
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod commands;
 mod gateway;
 mod importer;
 mod model;
+mod settings;
 mod vault;
 
 use std::sync::Arc;

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,0 +1,107 @@
+//! Preferences that are not secrets and not connections.
+//!
+//! The vault is encrypted and holds credentials; this file holds neither, so it stays plain JSON
+//! next to it. It exists because the update check is the first network request Remota makes
+//! without being asked, and a request like that needs an off switch the user can find.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Settings {
+    /// Whether Remota may ask GitHub if a newer release exists.
+    pub check_for_updates: bool,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self { check_for_updates: true }
+    }
+}
+
+/// `~/.config/remota/settings.json`, beside the vault.
+pub fn path() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("remota")
+        .join("settings.json")
+}
+
+impl Settings {
+    pub fn load() -> Self {
+        Self::load_from(&path())
+    }
+
+    /// A missing or unreadable file is a fresh install; a corrupt one is a file we cannot trust.
+    /// Both yield the defaults. Refusing to start because a preferences file is malformed would
+    /// cost someone every connection they own over a setting that does not matter.
+    pub fn load_from(path: &std::path::Path) -> Self {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|raw| serde_json::from_str(&raw).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn save(&self) -> Result<(), String> {
+        self.save_to(&path())
+    }
+
+    pub fn save_to(&self, path: &std::path::Path) -> Result<(), String> {
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+        }
+        let json = serde_json::to_vec_pretty(self).map_err(|e| e.to_string())?;
+        std::fs::write(path, json).map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("remota-settings-test-{name}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        dir.join("settings.json")
+    }
+
+    #[test]
+    fn a_fresh_install_checks_for_updates() {
+        assert!(Settings::default().check_for_updates);
+    }
+
+    #[test]
+    fn a_missing_file_is_a_fresh_install() {
+        let p = temp("missing");
+        assert_eq!(Settings::load_from(&p), Settings::default());
+    }
+
+    #[test]
+    fn a_corrupt_file_falls_back_instead_of_failing() {
+        // Refusing to start over a malformed preferences file would cost someone every
+        // connection they own for the sake of one boolean.
+        let p = temp("corrupt");
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, b"{ this is not json").unwrap();
+        assert_eq!(Settings::load_from(&p), Settings::default());
+    }
+
+    #[test]
+    fn an_unknown_field_does_not_discard_the_known_ones() {
+        // A settings file written by a newer Remota must still load in an older one.
+        let p = temp("unknown");
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, br#"{"check_for_updates": false, "future_option": 7}"#).unwrap();
+        assert!(!Settings::load_from(&p).check_for_updates);
+    }
+
+    #[test]
+    fn saving_then_loading_round_trips() {
+        let p = temp("roundtrip");
+        let s = Settings { check_for_updates: false };
+        s.save_to(&p).unwrap();
+        assert_eq!(Settings::load_from(&p), s);
+    }
+}

--- a/src-tauri/src/update.rs
+++ b/src-tauri/src/update.rs
@@ -1,0 +1,139 @@
+//! How a new version reaches an installation.
+//!
+//! An AppImage is a single file the running process owns; it replaces itself and restarts without
+//! asking anyone for anything. A `.deb` or `.rpm` belongs to the system package manager, so
+//! replacing one runs `dpkg`/`rpm` through `pkexec` and the system puts up its administrator
+//! prompt.
+//!
+//! That difference is not an implementation detail to hide. Someone who clicks "Update" and is
+//! unexpectedly asked for a root password learns to type root passwords into whatever asks — and
+//! this application manages SSH keys, bastion credentials and remote desktops. Teaching that habit
+//! would cost more than the stale version it fixed. So the interface says which of the two is
+//! about to happen, before the click.
+
+use serde::Serialize;
+
+/// Where someone is sent when Remota cannot finish the job itself.
+pub const RELEASES_URL: &str = "https://github.com/privum-cloud/remota/releases/latest";
+
+/// What installing a new version will cost the person watching.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Delivery {
+    /// Replaces itself and restarts. Nothing is asked of the user.
+    SelfInstall,
+    /// Can replace itself, but the system will ask for an administrator password first, because
+    /// the package manager owns the files.
+    NeedsAdmin,
+}
+
+/// Decide from what the running process can see.
+///
+/// `appimage` is the `APPIMAGE` environment variable, which the AppImage runtime sets to the path
+/// of the image it is running. Nothing else sets it, so its presence is what separates an AppImage
+/// from a `.deb` or `.rpm` unpacked into the same place on disk.
+pub fn delivery_from(appimage: Option<&str>) -> Delivery {
+    if appimage.is_some_and(|path| !path.is_empty()) {
+        Delivery::SelfInstall
+    } else {
+        Delivery::NeedsAdmin
+    }
+}
+
+/// Decide for the process running right now.
+pub fn delivery() -> Delivery {
+    delivery_from(std::env::var("APPIMAGE").ok().as_deref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_appimage_is_one_file_the_process_already_owns() {
+        assert_eq!(
+            delivery_from(Some("/home/someone/Apps/Remota.AppImage")),
+            Delivery::SelfInstall
+        );
+    }
+
+    #[test]
+    fn a_package_managed_install_warns_that_a_password_is_coming() {
+        assert_eq!(delivery_from(None), Delivery::NeedsAdmin);
+    }
+
+    #[test]
+    fn an_empty_appimage_variable_is_not_an_appimage() {
+        // An exported-but-empty variable is a shell leaving something behind, not a runtime
+        // announcing itself. Believing it would promise a quiet update and then produce a
+        // password prompt anyway.
+        assert_eq!(delivery_from(Some("")), Delivery::NeedsAdmin);
+    }
+
+    #[test]
+    fn every_updater_endpoint_is_https() {
+        // The plugin refuses a plain-http endpoint, and it refuses it during initialisation —
+        // which takes the whole application down with it. The window never opens, so the vault
+        // never opens, so one wrong line of configuration costs somebody every connection they
+        // own.
+        //
+        // Nothing else catches this. No test builds a window, CI never launches one, and the
+        // configuration is compiled into the binary — so reading the file here is reading exactly
+        // what ships.
+        let config = shipped_config();
+        let endpoints = config["plugins"]["updater"]["endpoints"]
+            .as_array()
+            .expect("the updater needs somewhere to ask");
+        assert!(!endpoints.is_empty(), "an updater with no endpoint asks nobody");
+
+        for endpoint in endpoints {
+            let url = endpoint.as_str().expect("endpoints are strings");
+            assert!(
+                url.starts_with("https://"),
+                "the updater refuses this at startup and the app will not open: {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_configured_public_key_is_the_remota_key() {
+        // Pasting another project's key here would ship an app that rejects every update we sign,
+        // and the failure would only appear on someone else's machine.
+        let config = shipped_config();
+        let pubkey = config["plugins"]["updater"]["pubkey"]
+            .as_str()
+            .expect("the updater needs a public key");
+        let decoded =
+            String::from_utf8(base64_decode(pubkey).expect("the pubkey is base64")).expect("text");
+        assert!(
+            decoded.contains("3FFC41078BBA8B43"),
+            "this is not Remota's signing key: {decoded}"
+        );
+    }
+
+    /// The configuration as it will be compiled into the binary.
+    fn shipped_config() -> serde_json::Value {
+        let raw = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/tauri.conf.json"))
+            .expect("tauri.conf.json sits beside Cargo.toml");
+        serde_json::from_str(&raw).expect("valid JSON")
+    }
+
+    /// Minimal base64 decode, so the test needs no new dependency.
+    fn base64_decode(s: &str) -> Option<Vec<u8>> {
+        const TABLE: &[u8; 64] =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        let mut out = Vec::new();
+        let mut buf = 0u32;
+        let mut bits = 0u32;
+        for c in s.bytes().filter(|c| !c.is_ascii_whitespace() && *c != b'=') {
+            let v = TABLE.iter().position(|t| *t == c)? as u32;
+            buf = (buf << 6) | v;
+            bits += 6;
+            if bits >= 8 {
+                bits -= 8;
+                out.push((buf >> bits) as u8);
+            }
+        }
+        Some(out)
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,6 +31,15 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "createUpdaterArtifacts": true
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDNGRkM0MTA3OEJCQThCNDMKUldSRGk3cUxCMEg4UDJqUkFWV21uWEwyOWtEVjVvcmpicFFsNEc3bFQ4cHhrN1lFd3dsRk1ocVQK",
+      "endpoints": [
+        "https://github.com/privum-cloud/remota/releases/latest/download/latest.json"
+      ]
+    }
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -197,6 +197,22 @@ export default function App() {
     {
       title: "Help",
       items: [
+        {
+          // A check the user asked for reports the boring answer too; staying silent would look
+          // like the button did nothing.
+          label: "Check for updates now",
+          onClick: async () => {
+            const found = await u.checkNow();
+            if (!found) setNotice("Remota is up to date.");
+          },
+        },
+        {
+          label: u.policy?.enabled
+            ? "✓ Check for updates automatically"
+            : "Check for updates automatically",
+          onClick: () => void u.setEnabled(!u.policy?.enabled),
+        },
+        "sep",
         { label: "About Remota", onClick: () => setNotice("Remota — multi-protocol remote connection manager for Linux. Clean-room, AGPLv3.") },
       ],
     },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,9 @@
 import { type CSSProperties, type ReactNode, useState } from "react";
 import { useVault } from "./state/useVault";
 import { useSessions } from "./state/useSessions";
+import { useUpdate } from "./lib/useUpdate";
 import { VaultUnlock } from "./components/VaultUnlock";
+import { UpdateBanner } from "./components/UpdateBanner";
 import { ConnectionTree } from "./components/ConnectionTree";
 import { ConnectionEditor } from "./components/ConnectionEditor";
 import { FolderEditor } from "./components/FolderEditor";
@@ -21,12 +23,34 @@ type Editing = { kind: "connection" | "folder"; node: Node | null; parentId: str
 export default function App() {
   const v = useVault();
   const s = useSessions();
+  const u = useUpdate();
   const [editing, setEditing] = useState<Editing>({ kind: "connection", node: null, parentId: null });
   const [active, setActive] = useState<string>("editor");
   const [notice, setNotice] = useState<string | null>(null);
 
+  // Built once and rendered in every branch below — including the locked screen. Whoever has not
+  // opened Remota in a month is exactly the person who has not heard about the release that fixed
+  // something, and they should not have to unlock a vault to find out.
+  const updateBanner = u.policy ? (
+    <UpdateBanner
+      phase={u.phase}
+      delivery={u.policy.delivery}
+      releasesUrl={u.policy.releasesUrl}
+      onInstall={u.install}
+      onDismiss={u.dismiss}
+    />
+  ) : null;
+
   if (v.status === "checking") return <Center>Checking vault…</Center>;
-  if (v.status === "locked") return <VaultUnlock exists={v.exists} error={v.error} onUnlock={v.unlock} />;
+  if (v.status === "locked")
+    return (
+      <div style={{ display: "flex", flexDirection: "column", height: "100vh" }}>
+        {updateBanner}
+        <div style={{ flex: 1, minHeight: 0 }}>
+          <VaultUnlock exists={v.exists} error={v.error} onUnlock={v.unlock} />
+        </div>
+      </div>
+    );
 
   const selected = editing.node;
   // novo nó vai dentro da pasta selecionada (se houver), senão na raiz.
@@ -181,6 +205,7 @@ export default function App() {
   return (
     <div style={shell}>
       <MenuBar menus={menus} />
+      {updateBanner}
       <div className="tricolore">
         <span style={{ background: "#009246" }} />
         <span style={{ background: "#f4f4f4" }} />

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -1,0 +1,81 @@
+import { type CSSProperties } from "react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+
+import type { UpdateDelivery } from "../lib/vaultApi";
+import type { UpdatePhase } from "../lib/useUpdate";
+import { colors, ghostBtn, primaryBtn } from "./styles";
+
+interface Props {
+  phase: UpdatePhase;
+  delivery: UpdateDelivery;
+  releasesUrl: string;
+  onInstall: () => void;
+  onDismiss: () => void;
+}
+
+export function UpdateBanner({ phase, delivery, releasesUrl, onInstall, onDismiss }: Props) {
+  if (phase.name === "quiet") return null;
+
+  const openReleases = () => void openUrl(releasesUrl);
+
+  if (phase.name === "installing") {
+    return (
+      <div style={bar} role="status">
+        <span style={text}>
+          {phase.percent === null ? "Downloading…" : `Downloading… ${phase.percent}%`}
+        </span>
+      </div>
+    );
+  }
+
+  if (phase.name === "installed") {
+    return (
+      <div style={bar} role="status">
+        <span style={text}>Installed. Restarting…</span>
+      </div>
+    );
+  }
+
+  if (phase.name === "failed") {
+    return (
+      <div style={{ ...bar, borderBottom: `1px solid ${colors.danger}` }} role="alert">
+        <span style={text}>The update could not be installed. {phase.message}</span>
+        <button style={{ ...ghostBtn, marginLeft: "auto" }} onClick={openReleases}>
+          Download it
+        </button>
+        <button style={ghostBtn} onClick={onDismiss}>
+          Not now
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={bar} role="status">
+      <span style={text}>
+        Remota {phase.version} is out.
+        {delivery === "needs_admin" &&
+          // Said before the click, not after. Someone surprised by a root password prompt learns
+          // to type root passwords into surprises — and this app manages bastion credentials.
+          " Your system will ask for an administrator password, because your package manager owns this installation."}
+      </span>
+      <button style={{ ...primaryBtn, marginLeft: "auto" }} onClick={onInstall}>
+        Update
+      </button>
+      <button style={ghostBtn} onClick={onDismiss}>
+        Not now
+      </button>
+    </div>
+  );
+}
+
+const bar: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  padding: "8px 12px",
+  background: colors.panel,
+  borderBottom: `1px solid ${colors.border}`,
+  flexShrink: 0,
+};
+const text: CSSProperties = { fontSize: 13, color: colors.text };

--- a/src/lib/useUpdate.ts
+++ b/src/lib/useUpdate.ts
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { check, type Update } from "@tauri-apps/plugin-updater";
+import { relaunch } from "@tauri-apps/plugin-process";
+
+import { vaultApi, type UpdatePolicy } from "./vaultApi";
+
+/**
+ * Where the update conversation has got to.
+ *
+ * `quiet` covers every uninteresting case at once — no newer version, checking turned off, the
+ * machine offline — because they all mean the same thing to the person looking at the window:
+ * nothing to do.
+ */
+export type UpdatePhase =
+  | { name: "quiet" }
+  | { name: "available"; version: string }
+  | { name: "installing"; percent: number | null }
+  | { name: "installed" }
+  | { name: "failed"; message: string };
+
+export function useUpdate() {
+  const [policy, setPolicy] = useState<UpdatePolicy | null>(null);
+  const [phase, setPhase] = useState<UpdatePhase>({ name: "quiet" });
+  // Held from the check so installing does not have to ask again.
+  const pending = useRef<Update | null>(null);
+
+  const readPolicy = useCallback(async () => {
+    const next = await vaultApi.updatePolicy();
+    setPolicy(next);
+    return next;
+  }, []);
+
+  const look = useCallback(async () => {
+    try {
+      const found = await check();
+      if (!found) return false;
+      pending.current = found;
+      setPhase({ name: "available", version: found.version });
+      return true;
+    } catch {
+      // Offline, GitHub having a bad minute, a manifest not published yet. None of it is the
+      // user's problem, and none of it should interrupt someone who opened Remota to reach a
+      // server.
+      return false;
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      let current: UpdatePolicy;
+      try {
+        current = await readPolicy();
+      } catch {
+        // Without the policy we do not know whether we are allowed to look, and the safe reading
+        // of that is: do not.
+        return;
+      }
+      if (!current.enabled || cancelled) return;
+      await look();
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [readPolicy, look]);
+
+  /** Download and install, then restart into the new version. */
+  const install = useCallback(async () => {
+    const found = pending.current;
+    if (!found) return;
+
+    setPhase({ name: "installing", percent: null });
+    let total = 0;
+    let seen = 0;
+    try {
+      await found.downloadAndInstall((event) => {
+        if (event.event === "Started") {
+          total = event.data.contentLength ?? 0;
+          setPhase({ name: "installing", percent: total ? 0 : null });
+        } else if (event.event === "Progress") {
+          seen += event.data.chunkLength;
+          setPhase({
+            name: "installing",
+            percent: total ? Math.min(100, Math.round((seen / total) * 100)) : null,
+          });
+        } else if (event.event === "Finished") {
+          setPhase({ name: "installed" });
+        }
+      });
+      setPhase({ name: "installed" });
+      await relaunch();
+    } catch (e: unknown) {
+      // A cancelled administrator prompt lands here too, which is why the failure always offers
+      // the download page rather than only an apology.
+      setPhase({ name: "failed", message: String(e) });
+    }
+  }, []);
+
+  const dismiss = useCallback(() => setPhase({ name: "quiet" }), []);
+
+  /** Menu-driven check. Returns whether anything was found, so the caller can say "up to date". */
+  const checkNow = useCallback(async () => look(), [look]);
+
+  const setEnabled = useCallback(
+    async (enabled: boolean) => {
+      await vaultApi.setUpdateCheck(enabled);
+      await readPolicy();
+    },
+    [readPolicy],
+  );
+
+  return { policy, phase, install, dismiss, setEnabled, checkNow };
+}

--- a/src/lib/vaultApi.ts
+++ b/src/lib/vaultApi.ts
@@ -58,6 +58,16 @@ export interface Document {
   trash: TrashEntry[];
 }
 
+/** What installing a new version costs the user: nothing, or an administrator password. */
+export type UpdateDelivery = "self_install" | "needs_admin";
+
+export interface UpdatePolicy {
+  delivery: UpdateDelivery;
+  enabled: boolean;
+  releasesUrl: string;
+  currentVersion: string;
+}
+
 // Wrappers tipados dos comandos Tauri (Tauri v2 converte snake_case→camelCase nos args).
 export const vaultApi = {
   exists: () => invoke<boolean>("vault_exists"),
@@ -76,4 +86,6 @@ export const vaultApi = {
     invoke<{ connections: number; message: string }>("export_connections", { path }),
   importRemotaJson: (path: string) =>
     invoke<{ connections: number; message: string }>("import_remota_json", { path }),
+  updatePolicy: () => invoke<UpdatePolicy>("update_policy"),
+  setUpdateCheck: (enabled: boolean) => invoke<boolean>("set_update_check", { enabled }),
 };


### PR DESCRIPTION
When someone opens Remota and a newer release exists, the app says so and offers to install it. Today a user finds out only by visiting the releases page, so installations drift.

This is a port of the updater already shipping in `tessera-mfa-app` — same stack, proven in production, deliberately not reinvented.

## What the user sees

A banner, rendered **above the vault unlock screen** as well as the main window. Whoever has not opened Remota in a month is exactly the person who has not heard about the release that fixed something, and they should not have to unlock a vault to find out.

The banner says **before the click** whether installing will be silent or will ask for an administrator password. An AppImage is one file the running process owns and replaces itself; a `.deb` or `.rpm` belongs to the package manager, so it goes through `pkexec`. Someone surprised by a root password prompt learns to type root passwords into surprises — and this application manages SSH keys and bastion credentials.

`Help → Check for updates now` reports "up to date" rather than staying silent, and the automatic check has a visible off switch.

## Why there is an off switch

The README promises *"Nothing leaves your machine."* That is about the vault and stays true, but the update check is the first network request Remota makes without being asked. A claim like that earns an off switch for the one request that does go out. The preference lives in a new `~/.config/remota/settings.json`, which holds no secrets; a corrupt file falls back to the defaults rather than refusing to start.

## Pipeline

A tag `v*` now drives the release: draft → signed build of deb/rpm/AppImage → `latest.json` assembled from the `.sig` files → publish. The signing key lives only in repo secrets.

`ci.yml` is new too. Remota had no CI, so the first place a broken build surfaced was the release tag itself.

## Verification

- `cargo test` green, 40 tests, 4 live-infrastructure tests still ignored.
- `cargo clippy --all-targets` — no new warnings.
- `npm run build` clean.
- The manifest builder proved both ways: three platforms from three `.sig` files, and exit 1 on an empty directory.
- Two tests read the `tauri.conf.json` that gets compiled in: every endpoint is `https` (the plugin rejects `http` during init and the window never opens, so the vault never opens), and the public key is Remota's rather than another project's.

## Not verified yet, and cannot be until this ships

Nothing here proves a real signed update installs. That needs a published release, and it is the next step: cut 0.1.7, update the two operator machines manually one last time — **the 0.1.6 installs contain no updater and cannot be updated into this automatically** — then cut 0.1.8 and watch ironman receive it.