### PR TITLE
Release 0.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remota",
   "private": true,
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4106,7 +4106,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "remota"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "aes-gcm 0.10.3",
  "argon2 0.5.3",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "remota"
-version = "0.1.6"
+version = "0.1.7"
 description = "Remota — open-source multi-protocol remote connection manager for Linux"
 authors = ["Privum Cloud"]
 license = "AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Remota",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "identifier": "cloud.privum.remota",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to 0.1.7.

First release built and signed by CI, and the first version that later releases can be installed *into* automatically — 0.1.6 and earlier contain no updater and need one manual update.